### PR TITLE
Updated url to haraldtux rpieasy-update repo (cli-tools -> update)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ Other dependencies can be reached and installed through the webGUI after startin
 # Update
 There are an external updater and command line manager script by [haraldtux](/haraldtux):
 
-https://github.com/haraldtux/rpieasy-cli-tools
+https://github.com/haraldtux/rpieasy-update
 
 Or you can use the integrated updater at Tools->System Updates, but be warned: save your "data" directory before update if it is containing data that you can't or won't readd manually!


### PR DESCRIPTION
haraldtux seems to have renamed the repository which resulted in a broken link.