### PR TITLE
[Hardware] Add support for RPi 4 rev 1.5 hardware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+.vscode/settings.json

--- a/linux_os.py
+++ b/linux_os.py
@@ -496,6 +496,24 @@ def getRPIVer():
        "lan":"1",
        "bt":"1"
       }
+     elif (hwid in "c04170"):
+      hwarr = { 
+       "name": "Pi 5",
+       "ram": "4GB",
+       "pins": "40",
+       "wlan": "1",
+       "lan":"1",
+       "bt":"1"
+      }
+     elif (hwid in "d04170"):
+      hwarr = { 
+       "name": "Pi 5",
+       "ram": "8GB",
+       "pins": "40",
+       "wlan": "1",
+       "lan":"1",
+       "bt":"1"
+      }
     return hwarr
 
 def getsounddevs(playbackdevs = True):

--- a/linux_os.py
+++ b/linux_os.py
@@ -460,7 +460,7 @@ def getRPIVer():
        "lan":"1",
        "bt":"1"
       }
-     elif (hwid == "b03111") or (hwid == "b03112") or (hwid == "b03114"):
+     elif (hwid in "b03111,b03112,b03114"):
       hwarr = { 
        "name": "Pi 4 Model B",
        "ram": "2GB",
@@ -469,7 +469,7 @@ def getRPIVer():
        "lan":"1",
        "bt":"1"
       }
-     elif (hwid == "c03111") or (hwid == "c03112") or (hwid == "c03114"):
+     elif (hwid in "c03111,c03112,c03114,c03115"):
       hwarr = { 
        "name": "Pi 4 Model B",
        "ram": "4GB",
@@ -487,7 +487,7 @@ def getRPIVer():
        "lan":"1",
        "bt":"1"
       }
-     elif (hwid == "d03114"):
+     elif (hwid in "d03114,d03115"):
       hwarr = { 
        "name": "Pi 4 Model B",
        "ram": "8GB",

--- a/rpieGlobals.py
+++ b/rpieGlobals.py
@@ -6,7 +6,7 @@
 # Copyright (C) 2018-2023 by Alexander Nagy - https://bitekmindenhol.blog.hu/
 #
 PROGNAME = "RPIEasy"
-BUILD   = 23273
+BUILD   = 23275
 PROGVER = str(BUILD)[:1]+"."+str(BUILD)[1:2]+"."+str(BUILD)[2:]
 
 gpMenu = []


### PR DESCRIPTION
Resolves #282 

Features:
- Add support for RPi 4 rev. 1.5 hardware, both 4GB and 8GB
- Add `.vscode` folder to `.gitignore` file
- Add preliminary support for RPi 5 hardware, both 4GB and 8GB
- Incremented the version number, 1x for RPi4 update, and 1x for RPi5 addition

NB: RPi 5 hardware revisions taken from [official Raspberry Pi documentation](https://github.com/raspberrypi/documentation/blob/develop/documentation/asciidoc/computers/raspberry-pi/revision-codes.adoc)

Suggestion: Use the detection logic shown in that page, including a Python example.